### PR TITLE
Adds missing mouse events to Link

### DIFF
--- a/packages/mobx-little-router-react/src/components/Link.js
+++ b/packages/mobx-little-router-react/src/components/Link.js
@@ -38,7 +38,7 @@ class Link extends Component<Props> {
 
   render() {
     const { router } = this.context
-    const { to, className, activeClassName, style, children, exact } = this.props
+    const { to, className, activeClassName, style, children, exact, onMouseEnter, onMouseLeave } = this.props
     const href = typeof to === 'object'
       ? locationToHref(to)
       : to
@@ -48,7 +48,7 @@ class Link extends Component<Props> {
     const matcher = new RegExp(`${matchPrefix}${typeof href === 'string' ? href.replace(/(\?.*)?$/, '') : ''}${matchSuffix}`)
     const isActive = matcher.test(this.context.router.store.location.pathname)
 
-    return <a href={router.createHref(href)} className={cx(className, typeof activeClassName ==='string' && { [activeClassName]: isActive })} style={style} onClick={this.onClick}>{children}</a>
+    return <a href={router.createHref(href)} className={cx(className, typeof activeClassName ==='string' && { [activeClassName]: isActive })} style={style} onClick={this.onClick} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>{children}</a>
   }
 }
 
@@ -56,7 +56,7 @@ const locationToHref = (location: LocationShape) => {
   const queryString = QueryString.stringify(location.query)
   const hash = location.hash || ''
   const search = (queryString ? `?${queryString}` : location.search) || ''
-  
+
   return `${location.pathname}${hash}${search}`
 }
 

--- a/packages/mobx-little-router-react/src/components/Link.js
+++ b/packages/mobx-little-router-react/src/components/Link.js
@@ -15,9 +15,7 @@ type Props =  {
   children?: Element<*>,
   exact?: boolean,
   reload?: boolean,
-  onClick: Function,
-  onMouseEnter: Function,
-  onMouseLeave: Function
+  onClick: Function
 }
 
 class Link extends Component<Props> {
@@ -40,7 +38,7 @@ class Link extends Component<Props> {
 
   render() {
     const { router } = this.context
-    const { to, className, activeClassName, style, children, exact, onMouseEnter, onMouseLeave } = this.props
+    const { to, className, activeClassName, style, children, exact, reload, onClick, ...rest } = this.props
     const href = typeof to === 'object'
       ? locationToHref(to)
       : to
@@ -50,7 +48,7 @@ class Link extends Component<Props> {
     const matcher = new RegExp(`${matchPrefix}${typeof href === 'string' ? href.replace(/(\?.*)?$/, '') : ''}${matchSuffix}`)
     const isActive = matcher.test(this.context.router.store.location.pathname)
 
-    return <a href={router.createHref(href)} className={cx(className, typeof activeClassName ==='string' && { [activeClassName]: isActive })} style={style} onClick={this.onClick} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>{children}</a>
+    return <a href={router.createHref(href)} className={cx(className, typeof activeClassName ==='string' && { [activeClassName]: isActive })} style={style} onClick={this.onClick} {...rest}>{children}</a>
   }
 }
 

--- a/packages/mobx-little-router-react/src/components/Link.js
+++ b/packages/mobx-little-router-react/src/components/Link.js
@@ -15,7 +15,9 @@ type Props =  {
   children?: Element<*>,
   exact?: boolean,
   reload?: boolean,
-  onClick: Function
+  onClick: Function,
+  onMouseEnter: Function,
+  onMouseLeave: Function
 }
 
 class Link extends Component<Props> {

--- a/packages/mobx-little-router-react/src/components/Link.test.js
+++ b/packages/mobx-little-router-react/src/components/Link.test.js
@@ -42,7 +42,7 @@ describe('Link', () => {
 
     wrapper.find('.index').simulate('click')
     await delay(0)
-    
+
     expect(router.store.location.pathname).toEqual('/')
   })
 
@@ -68,6 +68,34 @@ describe('Link', () => {
     )
 
     wrapper.find('.foo').simulate('click')
+    await delay(0)
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('supports onMouseEnter prop', async () => {
+    const spy = jest.fn()
+    const wrapper = mountInProvider(router)(
+      <div>
+        <Link onMouseEnter={spy} className="foo" to="/foo">Foo</Link>
+      </div>
+    )
+
+    wrapper.find('.foo').simulate('mouseenter')
+    await delay(0)
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('supports onMouseLeave prop', async () => {
+    const spy = jest.fn()
+    const wrapper = mountInProvider(router)(
+      <div>
+        <Link onMouseLeave={spy} className="foo" to="/foo">Foo</Link>
+      </div>
+    )
+
+    wrapper.find('.foo').simulate('mouseleave')
     await delay(0)
 
     expect(spy).toHaveBeenCalled()


### PR DESCRIPTION
Link strips all mouse events except for `onClick`. ~Might be a good idea to add the remaining [mouse events](https://reactjs.org/docs/events.html#mouse-events) in the future~. Supports any prop now.