### PR TITLE
60 - Adds serialization and hydration for route states.

### DIFF
--- a/packages/mobx-little-router-react/src/middleware/transformReactConfig.test.js
+++ b/packages/mobx-little-router-react/src/middleware/transformReactConfig.test.js
@@ -12,7 +12,7 @@ describe('transformReactConfig middleware', () => {
       type: EventTypes.CHILDREN_LOADING,
       leaf: createLeaf(),
       navigation: createNavigation(),
-      partialPath: [],
+      partialPath: null,
       children: [
         { path: 'b', component: B, outlet: 'modal' },
         { path: 'c', component: C, children: [{ path: 'd', component: D }] }

--- a/packages/mobx-little-router/src/Router.js
+++ b/packages/mobx-little-router/src/Router.js
@@ -22,9 +22,21 @@ import type {
 import Scheduler from './scheduling/Scheduler'
 import { type Event, EventTypes } from './events'
 import { NavigationTypes } from './model/Navigation'
+import { EMPTY } from './middleware/Middleware'
 import type { IMiddleware } from './middleware/Middleware'
 
 const OBSERVABLE_ROUTE_PROPERTIES = ['params', 'query', 'computed']
+
+type RouterCtorOptions = {
+  getContext?: void | (() => any),
+  middleware?: IMiddleware,
+  ssr?: {
+    state: Object
+  }
+}
+const DEFAULT_OPTIONS: RouterCtorOptions= {
+  middleware: EMPTY
+}
 
 class Router {
   // Public members
@@ -42,10 +54,10 @@ class Router {
   _disposers: Function[]
   _nextNavigation: * // This is computed from Scheduler event observable.
 
-  constructor(history: History, config: Config<*>[], getContext?: void | (() => any), middleware: IMiddleware) {
-    const root = createRouteStateTreeNode({ key: '@@ROOT', path: '', match: 'partial' }, getContext) // Initial root.
-    const store = new RouterStore(root)
-    const scheduler = new Scheduler(store, middleware)
+  constructor(history: History, config: Config<*>[], opts?: RouterCtorOptions = DEFAULT_OPTIONS) {
+    const root = createRouteStateTreeNode({ key: '@@ROOT', path: '', match: 'partial' }, opts.getContext) // Initial root.
+    const store = new RouterStore(root, opts.ssr ? opts.ssr.state : undefined)
+    const scheduler = new Scheduler(store, opts.middleware || EMPTY)
     extendObservable(
       this,
       {

--- a/packages/mobx-little-router/src/Router.test.js
+++ b/packages/mobx-little-router/src/Router.test.js
@@ -40,8 +40,9 @@ describe('Router', () => {
         { key: 'b', path: 'b' },
         { key: 'c', path: 'c' }
       ],
-      () => ({ message: 'Hello' }),
-      Middleware.EMPTY
+      {
+        getContext: () => ({ message: 'Hello' })
+      }
     )
 
     return router.start()
@@ -174,9 +175,7 @@ describe('Router', () => {
             }
           ]
         }
-      ],
-      () => ({}),
-      Middleware.EMPTY
+      ]
     )
     await router.start()
 
@@ -198,7 +197,11 @@ describe('Router', () => {
     })
 
     const dispose1 = autorun(() => {
-      const { user: { params: { id } } } = userData
+      const {
+        user: {
+          params: { id }
+        }
+      } = userData
       spy1(id)
     })
 

--- a/packages/mobx-little-router/src/index.js
+++ b/packages/mobx-little-router/src/index.js
@@ -1,34 +1,11 @@
 // @flow
-import Router from './Router'
 import type { Config } from './model/types'
 import type { Event } from './events'
 import type { History } from 'history'
-import Middleware from './middleware/Middleware'
 import type { IMiddleware } from './middleware/Middleware'
-import withQueryMiddleware from './middleware/withQueryMiddleware'
-import withRelativePath from './middleware/withRelativePath'
-import withRedirect from './middleware/withRedirect'
-import devTools from './middleware/devTools'
 
-export type InstallOptions = {
-  history: History,
-  routes: Config<*>[],
-  getContext?: () => any,
-  middleware?: IMiddleware
-}
-
-export function install(opts: InstallOptions): Router {
-  return new Router(
-    opts.history,
-    opts.routes,
-    opts.getContext,
-    withQueryMiddleware
-      .concat(opts.middleware || Middleware.EMPTY)
-      .concat(withRedirect)
-      .concat(withRelativePath)
-      .concat(devTools) // devTools always has to be the last in case there are any config/node transforms
-  )
-}
+export { default as install } from './install'
+export type { InstallOptions } from './install'
 
 export { default as RouterStore } from './model/RouterStore'
 
@@ -52,6 +29,8 @@ export type { Event } from './events'
 export { TransitionTypes } from './transition/types'
 export type { TransitionType, TransitionEvent, TransitionFn } from './transition/types'
 
+export { serialize } from './serialization'
+
 export { default as Middleware } from './middleware/Middleware'
 export { default as transformConfigLoad } from './middleware/transformConfigLoad'
 export { default as transformConfig } from './middleware/transformConfig'
@@ -63,10 +42,4 @@ export { default as areRoutesEqual } from './model/util/areRoutesEqual'
 
 export type { IMiddleware } from './middleware/Middleware'
 
-export {
-  RouteError,
-  NotFound,
-  Unauthorized,
-  AuthenticationTimeout,
-  BadRequest
-} from './errors'
+export { RouteError, NotFound, Unauthorized, AuthenticationTimeout, BadRequest } from './errors'

--- a/packages/mobx-little-router/src/install.js
+++ b/packages/mobx-little-router/src/install.js
@@ -1,0 +1,37 @@
+// @flow
+import { History } from 'history'
+import type { Config } from './model/types'
+import type { IMiddleware } from './middleware/Middleware'
+import Middleware from './middleware/Middleware'
+import Router from './Router'
+import withQueryMiddleware from './middleware/withQueryMiddleware'
+import withRedirect from './middleware/withRedirect'
+import withRelativePath from './middleware/withRelativePath'
+import devTools from './middleware/devTools'
+
+export type SsrOptions = {
+  state: Object
+}
+
+export type InstallOptions = {
+  history: History,
+  routes: Config<*>[],
+  getContext?: () => any,
+  middleware?: IMiddleware,
+  ssr?: SsrOptions
+}
+
+export default function install(opts: InstallOptions): Router {
+  return new Router(
+    opts.history,
+    opts.routes, {
+      ssr: opts.ssr,
+      getContext: opts.getContext,
+      middleware: withQueryMiddleware
+        .concat(opts.middleware || Middleware.EMPTY)
+        .concat(withRedirect)
+        .concat(withRelativePath)
+        .concat(devTools) // devTools always has to be the last in case there are any config/node transforms
+    }
+  )
+}

--- a/packages/mobx-little-router/src/middleware/Middleware.js
+++ b/packages/mobx-little-router/src/middleware/Middleware.js
@@ -26,4 +26,7 @@ export default function Middleware(f: Computation): IMiddleware {
   }
 }
 
-Middleware.EMPTY = Middleware(x => x)
+const EMPTY = Middleware(x => x)
+Middleware.EMPTY = EMPTY
+
+export { EMPTY }

--- a/packages/mobx-little-router/src/model/createRouteInstance.js
+++ b/packages/mobx-little-router/src/model/createRouteInstance.js
@@ -6,24 +6,35 @@ import createRoutePropsWrapper from './createRoutePropsWrapper'
 
 import type { Params, Query, Route, RouteStateTreeNode } from './types'
 
-export default function createRouteInstance<C: Object, D: Object>(node: RouteStateTreeNode<C, D>, parentUrl: string, segment: string, params: Params, query: Query, ancestors: Array<Route<*, *>> = []): Route<C,D> {
-  const route = observable({
-    node,
-    key: createRouteKey(node, `${parentUrl}:${segment}:${qs.stringify(query)}`),
-    value: `${parentUrl}${segment}?${qs.stringify(query)}`,
-    parentUrl,
-    segment,
-    params,
-    query,
-    state: { ...node.value.state },
-    context: node.value.getContext(),
-    onTransition: node.value.onTransition,
-    disposers: [],
-    ancestors
-  }, {
-    node: observable.ref,
-    context: observable.ref
-  })
+export default function createRouteInstance<C: Object, D: Object>(
+  node: RouteStateTreeNode<C, D>,
+  parentUrl: string,
+  segment: string,
+  params: Params,
+  query: Query,
+  ancestors: Array<Route<*, *>> = [],
+  initialState?: Object = {}
+): Route<C, D> {
+  const route = observable(
+    {
+      node,
+      key: createRouteKey(node, `${parentUrl}:${segment}:${qs.stringify(query)}`),
+      value: `${parentUrl}${segment}?${qs.stringify(query)}`,
+      parentUrl,
+      segment,
+      params,
+      query,
+      state: { ...node.value.state, ...initialState },
+      context: node.value.getContext(),
+      onTransition: node.value.onTransition,
+      disposers: [],
+      ancestors
+    },
+    {
+      node: observable.ref,
+      context: observable.ref
+    }
+  )
 
   extendObservable(route, {
     computed: node.value.computed(createRoutePropsWrapper(route)),

--- a/packages/mobx-little-router/src/model/createRoutePropsWrapper.js
+++ b/packages/mobx-little-router/src/model/createRoutePropsWrapper.js
@@ -1,5 +1,4 @@
 // @flow
-import type RouterStore from './RouterStore'
 import type { Route, RouteProps } from './types'
 
 type RoutePropsWrapper = RouteProps & {
@@ -30,12 +29,14 @@ export default function createRoutePropsWrapper(route: Route<*, *>, useNode: boo
 
   const { defineProperty } = Object
   defineProperty(wrapped, 'state', {
+    enumerable: true,
     get() {
       return useNode ? current.state : route.state
     }
   })
 
   defineProperty(wrapped, 'computed', {
+    enumerable: true,
     get() {
       return useNode ? current.computed : route.computed
     }

--- a/packages/mobx-little-router/src/public.api.test.js
+++ b/packages/mobx-little-router/src/public.api.test.js
@@ -155,7 +155,6 @@ describe('Public API', () => {
   test('errors', async () => {
     router = install({
       history: createMemoryHistory({ initialEntries: ['/404'] }),
-      getContext: () => ({}),
       routes: [{ path: '' }]
     })
     await expect(router.start()).rejects.toEqual(expect.any(NotFound))
@@ -218,7 +217,6 @@ describe('Public API', () => {
   test('catch-all routes', async () => {
     const router = install({
       history: createMemoryHistory({ initialEntries: ['/a'], initialIndex: 0 }),
-      getContext: () => ({}),
       routes: [{ path: 'a' }, { path: '**' }]
     })
 
@@ -241,9 +239,9 @@ describe('Public API', () => {
 
     const router = install({
       history: createMemoryHistory({ initialEntries: ['/a/1'], initialIndex: 0 }),
-      getContext: () => ({}),
       routes: [
         {
+          key: 'a',
           path: 'a/:id',
           query: ['q'],
           willActivate: willActivateSpy,
@@ -277,7 +275,6 @@ describe('Public API', () => {
 
     const router = install({
       history: createMemoryHistory({ initialEntries: ['/'], initialIndex: 0 }),
-      getContext: () => ({}),
       routes: [
         {
           path: 'a/:id',
@@ -474,7 +471,6 @@ describe('Public API', () => {
 
     const router = install({
       history: createMemoryHistory({ initialEntries: ['/a'], initialIndex: 0 }),
-      getContext: () => ({}),
       middleware: Middleware(middleware),
       routes: [
         {
@@ -940,7 +936,6 @@ describe('Public API', () => {
     for (const type of types) {
       router = install({
         history: createMemoryHistory({ initialEntries: ['/'] }),
-        getContext: () => ({}),
         routes: [
           {
             path: '',

--- a/packages/mobx-little-router/src/serialization/index.js
+++ b/packages/mobx-little-router/src/serialization/index.js
@@ -1,0 +1,31 @@
+// @flow
+import type Router from '../Router'
+import type RouterStore from '../model/RouterStore'
+import type { Route } from '../model/types'
+import { toJS } from 'mobx'
+
+export function serialize(router: Router) {
+  if (router.isNavigating) throw new Error('Cannot serialize a router that is navigating.')
+  return {
+    activatedRoutes: router.activatedRoutes.reduce((acc, r) => {
+      acc[r.node.value.key] = serializeActivatedRoute(r)
+      return acc
+    }, {}),
+    store: serializeStore(router._store)
+  }
+}
+
+function serializeActivatedRoute(route: Route<*, *>) {
+  return {
+    key: route.key,
+    nodeKey: route.node.value.key,
+    state: toJS(route.state)
+  }
+}
+
+function serializeStore(store: RouterStore) {
+  return {
+    location: toJS(store.location),
+    nextKey: store.nextKey
+  }
+}

--- a/packages/mobx-little-router/src/serialization/serialization.test.js
+++ b/packages/mobx-little-router/src/serialization/serialization.test.js
@@ -1,0 +1,89 @@
+// @flow
+import { autorun, flow, when } from 'mobx'
+import { createMemoryHistory } from 'history'
+import { serialize } from './index'
+import install from '../install'
+
+describe('serialization', () => {
+  let router
+
+  beforeEach(() => {
+    router = install({
+      history: createMemoryHistory(),
+      routes: [
+        {
+          key: 'a',
+          path: '/a'
+        },
+        {
+          key: 'b',
+          path: '/b'
+        },
+        {
+          key: 'c',
+          path: '/c',
+          loadChildren: () =>
+            Promise.resolve([
+              {
+                key: 'd',
+                path: '/d',
+                query: ['q'],
+                loadChildren: () =>
+                  Promise.resolve([
+                    {
+                      key: 'e',
+                      path: '/e(/:id)',
+                      state: {
+                        isReady: false,
+                        item: null
+                      },
+                      subscriptions: route => {
+                        const { params } = route
+                        return autorun(async () => {
+                          route.state.item = await getItem(params.id)
+                          route.state.isReady = true
+                        })
+                      },
+                      willResolve: route => when(() => route.state.isReady)
+                    }
+                  ])
+              }
+            ])
+        }
+      ]
+    })
+
+    return router.start()
+  })
+
+  afterEach(() => router.stop())
+
+  test('errors when serializing during navigation', () => {
+    router.push('/c/d/e/123')
+    expect(() => serialize(router)).toThrow(/navigating/i)
+  })
+
+  test('serialize preserves activated route states', async () => {
+    await router.push('/c/d/e/123?q=hello')
+
+    const serialized = serialize(router)
+
+    expect(serialized.activatedRoutes.e.state).toEqual({
+      isReady: true,
+      item: { id: '123', name: 'Item 123' }
+    })
+  })
+
+  test('serialize preserves store state', async () => {
+    await router.push('/c/d/e/123?q=hello')
+
+    const serialized = serialize(router)
+
+    expect(serialized.store.location).toEqual(expect.objectContaining({ pathname: '/c/d/e/123' }))
+    expect(serialized.store.nextKey).toEqual(router._store.nextKey)
+  })
+})
+
+function getItem(id) {
+  return Promise.resolve({ id, name: `Item ${id}` })
+}

--- a/packages/mobx-little-router/src/ssr.test.js
+++ b/packages/mobx-little-router/src/ssr.test.js
@@ -1,0 +1,110 @@
+// @flow
+import { autorun, toJS, when } from 'mobx'
+import { createMemoryHistory } from 'history'
+import { install, serialize } from './index'
+
+describe('SSR', () => {
+  test.only('to and from JS for server-side rendering', async () => {
+    let activeRouterNumber = null
+    const activeRoutesSpy = jest.fn()
+    const stateSpy = jest.fn()
+    const paramsSpy = jest.fn()
+
+    const ROUTES = [
+      { key: 'home', path: '/' },
+      {
+        key: 'a',
+        path: '/a/:id',
+        state: {
+          flag: false.valueOf()
+        },
+        willResolve: route =>
+          when(() => route.state.flag).then(() => {
+            stateSpy({
+              routerNumber: activeRouterNumber,
+              in: 'willResolve',
+              value: toJS(route.state)
+            })
+          }),
+        subscriptions(route) {
+          const { params } = route
+          return autorun(() => {
+            paramsSpy({
+              routerNumber: activeRouterNumber,
+              in: 'subscriptions',
+              value: toJS(params)
+            })
+            stateSpy({
+              routerNumber: activeRouterNumber,
+              in: 'subscriptions',
+              value: toJS(route.state)
+            })
+            if (params.id) {
+              route.state.flag = true
+            }
+          })
+        }
+      }
+    ]
+
+    const router1 = install({
+      history: createMemoryHistory({ initialEntries: ['/'], initialIndex: 0 }),
+      routes: ROUTES
+    })
+
+    activeRouterNumber = 1
+    autorun(() => {
+      activeRoutesSpy({
+        routeNumber: activeRouterNumber,
+        routes: router1.activatedRoutes.map(x => x.node.value.key)
+      })
+    })
+    await router1.start()
+    await router1.push('/a/1')
+
+    const router2 = install({
+      history: createMemoryHistory({ initialEntries: ['/a/1'], initialIndex: 0 }),
+      routes: ROUTES,
+      ssr: {
+        state: serialize(router1)
+      }
+    })
+
+    activeRouterNumber = 2
+    autorun(() => {
+      activeRoutesSpy({
+        routeNumber: activeRouterNumber,
+        routes: router2.activatedRoutes.map(x => x.node.value.key)
+      })
+    })
+    await router2.start()
+
+    expect(stateSpy.mock.calls.map(x => x[0])).toEqual([
+      { routerNumber: 1, in: 'subscriptions', value: { flag: false } },
+      { routerNumber: 1, in: 'willResolve', value: { flag: true } },
+
+      // Route state is restored from serialized state.
+      { routerNumber: 2, in: 'subscriptions', value: { flag: true } },
+      { routerNumber: 2, in: 'willResolve', value: { flag: true } }
+    ])
+
+    expect(paramsSpy.mock.calls.map(x => x[0])).toEqual([
+      { routerNumber: 1, in: 'subscriptions', value: { id: '1' } },
+      { routerNumber: 2, in: 'subscriptions', value: { id: '1' } }
+    ])
+
+    expect(activeRoutesSpy.mock.calls.map(x => x[0])).toEqual([
+      { routeNumber: 1, routes: [] },
+      { routeNumber: 1, routes: ['@@ROOT', 'home'] },
+      { routeNumber: 1, routes: ['@@ROOT', 'a'] },
+
+      // Activated route is restored from serialized state.
+      { routeNumber: 2, routes: [] },
+
+      { routeNumber: 2, routes: ['@@ROOT', 'a'] }
+    ])
+
+    router1.stop()
+    router2.stop()
+  })
+})

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  semi: false,
+  printWidth: 100,
+  singleQuote: true
+}


### PR DESCRIPTION
This PR adds a `serialize(router)` function that will return a plain object containing:

- Route instance states.
- Current `location`.
- `nextKey` for RouterStore.

When the router is started on the client, the serialized state can be passed as an option:

```js
const router = install({
      history: createBrowserHistory(),
      routes: ROUTES,
      ssr: {
        state: SERIALIZED_STATE
      }
    })
```

This will allow routes too access the same state that was set on the server.

**Note:** Initial navigation, subscriptions, activation hooks will all fire as they are normally done. If there is application logic to skip data fetching, then this needs to be done on the application-side. The router cannot reasonably predict this type of logic.